### PR TITLE
Add support for providing custom JSONDecoders

### DIFF
--- a/Sources/Querl/Classes/Pagination.swift
+++ b/Sources/Querl/Classes/Pagination.swift
@@ -49,9 +49,10 @@ public enum PagedResponseError: Error {
 public extension PagedResponse {
     /// Generate a `PagedResponse` container
     /// - Parameters:
-    ///   - result: The result of a GraphQL network request
+    ///   - data: The result of a GraphQL network request
+    ///   - decoder: `JSONDecoder` instance to use for decoding. Default `JSONDecoder` provided.
     /// - Throws: This initializer throws the usual JSON decoding errors, as well as errors if the given `connectionPath` does not end in a decodable `Connection` section.
-    init(_ data: Data) throws {
+    init(_ data: Data, decoder: JSONDecoder = JSONDecoder()) throws {
         guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
             throw PagedResponseError.incorrectFormat
         }
@@ -63,14 +64,14 @@ public extension PagedResponse {
         
         if let pageInfoJSON = connectionRoot["pageInfo"] {
             let pageInfoData = try JSONSerialization.data(withJSONObject: pageInfoJSON)
-            pageInfo = try JSONDecoder().decode(Pagination.self, from: pageInfoData)
+            pageInfo = try decoder.decode(Pagination.self, from: pageInfoData)
         } else {
             throw PagedResponseError.pageInfoNotFound
         }
         
         if let nodesJSON = connectionRoot["nodes"] {
             let nodesData = try JSONSerialization.data(withJSONObject: nodesJSON)
-            nodes = try JSONDecoder().decode([Q.PaginatedType].self, from: nodesData)
+            nodes = try decoder.decode([Q.PaginatedType].self, from: nodesData)
                 response = try Q.decodeResponse(data)
         } else {
             throw PagedResponseError.nodesNotFound

--- a/Sources/Querl/Classes/Query.swift
+++ b/Sources/Querl/Classes/Query.swift
@@ -54,7 +54,7 @@ struct WrappedQueryResponse<T: Decodable>: Decodable {
 }
 
 public extension Query {
-    static func decodeResponse(_ data: Data) throws -> Response {
-        try JSONDecoder().decode(WrappedQueryResponse<Response>.self, from: data).data
+    static func decodeResponse(_ data: Data, decoder: JSONDecoder = JSONDecoder()) throws -> Response {
+        try decoder.decode(WrappedQueryResponse<Response>.self, from: data).data
     }
 }


### PR DESCRIPTION
This is just a small change to allow (but not require) providing a custom `JSONDecoder` to decode results. This may be desired e.g. to set the `dateDecodingStrategy` or `keyDecodingStrategy` on the decoder, which would eliminate additional processing steps once the data has been decoded.

Default values are provided, so this change does not break the API with any existing code. Existing code will have the same behavior, which is using a `JSONDecoder` initialized to defaults.